### PR TITLE
Cloudflareのビルドでインストールするのを Hugo だけにする

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,53 +4,32 @@
 # @file
 # Builds a Hugo site hosted on a Cloudflare Worker.
 #
-# The Cloudflare Worker automatically installs Node.js dependencies.
+# Only Hugo is installed. This site needs nothing else:
+#   - Dart Sass — there are no .scss/.sass files in the project or the theme
+#   - Go — the theme is a git submodule, not a Hugo Module (no `module:` in hugo.yaml)
+#   - Node.js — js.Build uses Hugo's embedded esbuild, and Cloudflare runs
+#     wrangler with its own Node.js before this script starts
+# See ADR-0014.
 #------------------------------------------------------------------------------
 
 main() {
 
-  DART_SASS_VERSION=1.92.1
-  GO_VERSION=1.25.1
   HUGO_VERSION=0.165.0
-  NODE_VERSION=22.18.0
 
   export TZ=Europe/Oslo
 
-  # Install Dart Sass
-  echo "Installing Dart Sass ${DART_SASS_VERSION}..."
-  curl -sLJO "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-  tar -C "${HOME}/.local" -xf "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-  rm "dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz"
-  export PATH="${HOME}/.local/dart-sass:${PATH}"
-
-  # Install Go
-  echo "Installing Go ${GO_VERSION}..."
-  curl -sLJO "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
-  tar -C "${HOME}/.local" -xf "go${GO_VERSION}.linux-amd64.tar.gz"
-  rm "go${GO_VERSION}.linux-amd64.tar.gz"
-  export PATH="${HOME}/.local/go/bin:${PATH}"
-
   # Install Hugo
   echo "Installing Hugo ${HUGO_VERSION}..."
-  curl -sLJO "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-  mkdir "${HOME}/.local/hugo"
-  tar -C "${HOME}/.local/hugo" -xf "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
-  rm "hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+  curl -fsSL --retry 3 --retry-delay 2 -o hugo.tar.gz \
+    "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.tar.gz"
+  mkdir -p "${HOME}/.local/hugo"
+  tar -C "${HOME}/.local/hugo" -xf hugo.tar.gz
+  rm hugo.tar.gz
   export PATH="${HOME}/.local/hugo:${PATH}"
 
-  # Install Node.js
-  echo "Installing Node.js ${NODE_VERSION}..."
-  curl -sLJO "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"
-  tar -C "${HOME}/.local" -xf "node-v${NODE_VERSION}-linux-x64.tar.xz"
-  rm "node-v${NODE_VERSION}-linux-x64.tar.xz"
-  export PATH="${HOME}/.local/node-v${NODE_VERSION}-linux-x64/bin:${PATH}"
-
-  # Verify installations
-  echo "Verifying installations..."
-  echo Dart Sass: "$(sass --version)"
-  echo Go: "$(go version)"
+  # Verify installation
+  echo "Verifying installation..."
   echo Hugo: "$(hugo version)"
-  echo Node.js: "$(node --version)"
 
   # Configure Git
   echo "Configuring Git..."

--- a/docs/adr/0014-build-installs-hugo-only.md
+++ b/docs/adr/0014-build-installs-hugo-only.md
@@ -1,0 +1,47 @@
+# ADR-0014: Cloudflareのビルドでは Hugo だけをインストールする
+
+- ステータス: 採用
+- 日付: 2026-08-21
+
+## コンテキスト
+
+`build.sh`（Cloudflare Workers Builds のカスタムビルドコマンド）は Dart Sass・Go・Node.js・Hugo の4つを毎回ダウンロードしてインストールしていた。Hugo公式ドキュメントの Cloudflare ホスティング手順のテンプレートをそのまま持ってきたもので、当サイトが実際に何を使っているかとは無関係だった。
+
+2026-08-20、PR #20 のビルドがこれを踏んで失敗した。
+
+```
+[custom build] Installing Go 1.25.1...
+[custom build] gzip: stdin: not in gzip format
+[custom build] tar: Child returned status 1
+```
+
+Go のダウンロードが0.5秒で完了しており（75MBのtarballでは有り得ない）、実体はHTTPエラーページだった。`curl -sLJO` は `-s` でエラー出力を抑制し `-f` を付けていないため、HTTPエラーでも終了コード0を返してエラーページをファイルとして保存する。失敗が表面化するのは `tar` の段階で、メッセージからは何が起きたのか読み取れない。URL自体は健在で、一時的な障害だった。
+
+調査の結果、4つのうち Hugo 以外はどれも使われていないことが分かった。
+
+- **Dart Sass** — `.scss` / `.sass` ファイルがプロジェクトにもテーマにも1つもない
+- **Go** — `hugo.yaml` に `module:` ブロックがなく、テーマは git submodule 運用（ADR-0001）。Hugo Modules を使っていないので Go ツールチェインは不要
+- **Node.js** — テーマの `head.html` が `js.Build` を使うが、これは Hugo に組み込まれた esbuild で動く。`wrangler` は Cloudflare 側が自前の Node.js で `npx wrangler versions upload` として起動しており（`build.sh` はその中から呼ばれる）、`build.sh` が入れる Node.js は誰も参照していない
+
+`hugo` だけを PATH に置いた環境（Go・Dart Sass は未インストール、Node.js も除外）でクリーンクローンをビルドし、6212ページと `js.Build` 由来の検索バンドル `search.<hash>.js` が正常に生成されることを確認した。
+
+## 決定
+
+- `build.sh` がインストールするのは Hugo だけにする。Dart Sass・Go・Node.js のインストールは削除する
+- ダウンロードは `curl -fsSL --retry 3 --retry-delay 2 -o <file>` で行う。`-f` によりHTTPエラーで即座に終了コード非0となり、`set -euo pipefail` がその場でビルドを止める。壊れたファイルが `tar` に渡ることはなくなる
+- `mkdir` は `mkdir -p` にする。コンテナがキャッシュされて再実行された場合に `set -e` で落ちないようにするため
+
+`export TZ=Europe/Oslo` は記事の日付表示に影響するため変更しない。
+
+## 結果・影響
+
+- デプロイごとのダウンロードが約130MB減り、ビルド時間が短縮される
+- 外部ダウンロードの失敗点が4箇所から1箇所になった
+- ダウンロードが失敗したとき、`gzip: stdin: not in gzip format` ではなく curl のHTTPエラーで止まるため原因が読める
+- 将来 Sass を使う、あるいはテーマを Hugo Modules へ移行する場合は、`build.sh` に該当のインストールを戻す必要がある。本ADRを参照すれば「なぜ消えているのか」が分かる
+
+## 却下した代替案
+
+- **依存は残したまま `curl` に `-f --retry` だけ足す** — 失敗時のメッセージは読めるようになるが、使っていないものを毎回130MB落とし続ける理由がない
+- **何もせずリトライだけする** — 今回は一時障害なのでリトライで復旧するが、使っていない依存を抱えている限り同じ失敗を繰り返す
+- **`TZ=Europe/Oslo` も整理する** — Hugo公式テンプレート由来で当サイトに固有の意味はないが、変更すると記事の日付表示が変わりうるため触らない

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,3 +60,4 @@
 | [0010](0010-auto-tagger-two-step.md) | auto_taggerからclaude -p を排除し--extract/--applyの2段構成にする | 採用 |
 | [0011](0011-social-icons-on-author-page-only.md) | ソーシャルアイコンはホームに表示せず著者ページのみに表示する | 採用 |
 | [0012](0012-unprocessed-post-detection-by-git-history.md) | 未処理記事の判定はgit履歴（インポートbotしか触っていない）で行う | 採用 |
+| [0014](0014-build-installs-hugo-only.md) | Cloudflareのビルドでは Hugo だけをインストールする | 採用 |


### PR DESCRIPTION
PR #20 のビルドが失敗したのを調べた副産物。**PR #20 の変更内容とは無関係の、以前から存在した問題。**

## 何が起きたか

```
[custom build] Installing Go 1.25.1...
[custom build] gzip: stdin: not in gzip format
[custom build] tar: Child returned status 1
[custom build] tar: Error is not recoverable: exiting now
```

Go のダウンロードが 0.5 秒で完了している（75MB の tarball では有り得ない）。実体は HTTP エラーページだった。

`curl -sLJO` は `-s` でエラー出力を抑制し `-f` を付けていないため、HTTP エラーでも終了コード 0 を返し、エラーページをそのまま `go1.25.1.linux-amd64.tar.gz` として保存する。失敗が表面化するのは `tar` の段階で、メッセージからは何が起きたのか読み取れない。

URL 自体は健在なので、これは一時的な障害。リトライすれば通る。

## 使っていない依存を3つ落としていた

`build.sh` は Hugo 公式ドキュメントの Cloudflare ホスティング手順のテンプレート由来で、当サイトが実際に何を使うかとは無関係に4つのツールチェインを入れていた。調べたところ Hugo 以外はどれも使われていない。

| 依存 | サイズ | 使われているか |
|---|---|---|
| Dart Sass | ~5MB | いいえ — `.scss` / `.sass` がプロジェクトにもテーマにも1つもない |
| Go | ~75MB | いいえ — `hugo.yaml` に `module:` ブロックがなく、テーマは git submodule 運用 (ADR-0001)。Hugo Modules 不使用 |
| Node.js | ~50MB | いいえ — テーマの `head.html` が使う `js.Build` は Hugo 内蔵の esbuild で動く。`wrangler` は Cloudflare 側が自前の Node.js で `npx wrangler versions upload` として起動しており、`build.sh` が入れる Node.js は誰も参照していない |

つまりデプロイのたびに不要な約130MBを落とし、失敗する箇所を3つ余計に抱えていた。今回はそのうちの1つを踏んだ。

## 変更内容

- Dart Sass / Go / Node.js のインストールを削除
- ダウンロードを `curl -fsSL --retry 3 --retry-delay 2 -o hugo.tar.gz` に変更。`-f` により HTTP エラーで即座に終了コード非0となり、`set -euo pipefail` がその場でビルドを止める。壊れたファイルが `tar` に渡らなくなる
- `mkdir` → `mkdir -p`。コンテナがキャッシュされて再実行された場合に `set -e` で落ちないようにする

`export TZ=Europe/Oslo` は記事の日付表示に影響しうるため変更していない。

## 検証

- `hugo` だけを PATH に置いた環境（Go・Dart Sass は未インストール、Node.js も除外）でクリーンクローンをビルド。6212ページと `js.Build` 由来の検索バンドル `search.<hash>.js` が正常に生成されることを確認
- `curl -f` のガード動作を確認。存在しないバージョンを指定すると `curl: (56) The requested URL returned error: 404` で終了コード56、ファイルは作られない（従来は空でないエラーページが保存され `tar` に渡っていた）
- Hugo 0.165.0 の linux-amd64 tarball を実際にダウンロードして展開し、`hugo` バイナリが取り出せることを確認
- `bash -n build.sh` 通過

経緯は ADR-0014 に記録。

## マージ順の注意

`docs/adr/README.md` の一覧表に行を追加しているため、同じ箇所に ADR-0013 の行を足す #20 とコンフリクトします。どちらを先にマージしても、後者側で1行分の解決が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
